### PR TITLE
Added a link to new how-to article

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # This repo is (mostly) obsolete!
 
-Work on this repo stopped in order to shift to the [`990_long`](https://github.com/CharityNavigator/990_long) repo. In general, `990_long` is more likely to be more useful to you: it has data for every field in every version of the 990, rather than a select handful, as in this repo. On the other hand, this repo preserves the structure of the data, whereas `990_long` transforms the 990 data set into hundreds of millions of key-value pairs.
+Work on this repo stopped in order to shift to the [`990_long`](https://github.com/CharityNavigator/990_long) repo. In general, `990_long` is more likely to be more useful to you: it has data for every field in every version of the 990, rather than a select handful, as in this repo. On the other hand, this repo preserves the structure of the data, whereas `990_long` transforms the 990 data set into hundreds of millions of key-value pairs. 
 
 ## IRS 990 Toolkit
 
 This repository contains everything you need to get started exploring the IRS 990 dataset [hosted by Amazon Web Services on S3](https://aws.amazon.com/public-datasets/irs-990/). This includes instructions for an easier-to-use 990 database provided free to the public by [Charity Navigator](https://www.charitynavigator.org/).
+
+## Want to DIY?
+
+Since this library was written, more and more resources have become available for analyzing the IRS e-file dataset. If you want to build your own 990 analysis tool, the author of this library has written [a how-to article on Medium](https://medium.com/@open990/the-irs-990-e-file-dataset-getting-to-the-chocolatey-center-of-data-deliciousness-90f66097a600).
 
 ## Documentation
 


### PR DESCRIPTION
Added a link to an article explaining the data set and existing tools to analyze it in a bit more detail, with all due praise to Charity Navigator as a pioneer in the field. Goes over some solutions to technical issues, and mentions some off-the-shelf tools.